### PR TITLE
Fix SHP2 & DPU values

### DIFF
--- a/lib/ecoflow_data.js
+++ b/lib/ecoflow_data.js
@@ -2278,7 +2278,7 @@ const pstreamStates = {
 				mult: 1,
 				entity_type: 'sensor',
 				role: 'value',
-				name: 'Baiiery pack count'
+				name: 'Battery pack count'
 			},
 			c20ChgMaxWatts: {
 				min: 0,
@@ -2471,7 +2471,7 @@ const pstreamStates = {
 			},
 			inAc_5p8Pwr: {
 				min: 0,
-				max: 3600,
+				max: 7200,
 				unit_of_measurement: 'W',
 				mult: 1,
 				entity_type: 'sensor',
@@ -2834,7 +2834,7 @@ const pstreamStates = {
 				name: 'Maximum parallel voltage'
 			},
 			acOutFreq: {
-				min: 50,
+				min: 0,
 				max: 60,
 				unit_of_measurement: 'Hz',
 				mult: 1,
@@ -3135,7 +3135,7 @@ const pstreamStates = {
 			},
 			inAc_5p8Amp: {
 				min: 0,
-				max: 30,
+				max: 30.1,
 				unit_of_measurement: 'V',
 				mult: 1,
 				entity_type: 'sensor',
@@ -11864,8 +11864,7 @@ const pstationStatesDict = {
 			pv2ChargeType: { entity: 'diagnostic' },
 			pv2ChargeWatts: { entity: 'number' },
 			pvChargePrioSet: { entity: 'diagnostic' },
-			minAcoutSoc: { entity: 'number' },
-			bpPowerSoc: { entity: 'level' }
+			minAcoutSoc: { entity: 'number' }
 		},
 		action: {
 			latestQuotas: { entity: 'switch' },

--- a/lib/ef_shp2_data.js
+++ b/lib/ef_shp2_data.js
@@ -9,7 +9,7 @@ const panel2States = {
 				entity_type: 'sensor',
 				device_class: 'power',
 				role: 'value',
-				name: 'Backup charge power'
+				name: 'Master Grid Power'
 			},
 			bkpChWatt: {
 				min: 0,
@@ -23,7 +23,7 @@ const panel2States = {
 			},
 			backupDischargeTime: {
 				min: 0,
-				max: 30000,
+				max: 180000,
 				unit_of_measurement: 'min',
 				mult: 1,
 				entity_type: 'sensor',
@@ -73,7 +73,7 @@ const panel2States = {
 			},
 			wattInfoGridWatt: {
 				min: 0,
-				max: 12000,
+				max: 24000,
 				unit_of_measurement: 'W',
 				mult: 1,
 				entity_type: 'sensor',
@@ -86,13 +86,13 @@ const panel2States = {
 			sysTimezone: {
 				entity_type: 'text',
 				entity_category: 'diagnostic',
-				name: 'Backup charge power',
+				name: 'System Timezone',
 				role: 'info'
 			},
 			timezoneId: {
 				entity_type: 'text',
 				entity_category: 'diagnostic',
-				name: 'Backup charge power',
+				name: 'System Timezone Id',
 				role: 'info'
 			},
 			appMainVer: {
@@ -478,7 +478,7 @@ const panel2States = {
 		number: {
 			backupFullCap: {
 				min: 0,
-				max: 20000,
+				max: 100000,
 				unit_of_measurement: 'mAh',
 				mult: 1,
 				entity_type: 'sensor',
@@ -3150,7 +3150,7 @@ const panel2Ranges = {
 	panel2: {
 		backupIncreInfo: {
 			number: {
-				backupFullCap: { max: 12400 }
+				backupFullCap: { max: 92160 }
 			}
 		}
 	}


### PR DESCRIPTION
Trying to add this my ecoflow to my HASS install, and getting some warning messages in the log:

> 2024-11-22 02:00:13.726 - warn: ecoflow-mqtt.0 (5141) State value to set for "ecoflow-mqtt.0.[DPU].BackendRecordHeartbeatReport.acOutFreq" has value "0" less than min "50"
2024-11-22 06:13:34.189 - warn: ecoflow-mqtt.0 (5141) State value to set for "ecoflow-mqtt.0.[SHP2].ProtoTime.backupDischargeTime" has value "143999" greater than max "30000"
2024-11-22 06:40:36.428 - warn: ecoflow-mqtt.0 (5141) State value to set for "ecoflow-mqtt.0.[SHP2].backupIncreInfo.backupFullCap" has value "15114" greater than max "12400"
2024-11-22 06:41:27.085 - warn: ecoflow-mqtt.0 (5141) State value to set for "ecoflow-mqtt.0.[DPU].AppShowHeartbeatReport.inAc_5p8Pwr" has value "6971.2099609375" greater than max "3600"
2024-11-22 06:41:27.151 - warn: ecoflow-mqtt.0 (5141) State value to set for "ecoflow-mqtt.0.[DPU].BackendRecordHeartbeatReport.inAc_5p8Amp" has value "30.031476974487305" greater than max "30"
2024-11-22 06:25:21.490 - warn: ecoflow-mqtt.0 (5141) State value to set for "ecoflow-mqtt.0.[SHP2].ProtoTime.wattInfoGridWatt" has value "146241840" greater than max "12000"
2024-11-22 06:26:31.802 - warn: ecoflow-mqtt.0 (5141) State value to set for "ecoflow-mqtt.0.[SHP2].ProtoTime.bkpChWatt" has value "1142021" greater than max "7200"

And noticed some duplicated keys in my MQTT broker that made it confusing, because stuff wasn't named correctly. Also, `wattInfoGridWatt` is screwy, but I'm not sure how exactly yet. `bkpChWatt` is also screwy in a similar way.