### PR TITLE
Handle HomeAssistant restart

### DIFF
--- a/lib/adapter_utils.js
+++ b/lib/adapter_utils.js
@@ -258,6 +258,7 @@ async function createInfoStates(adapter, haenable) {
 			native: {}
 		});
 		await adapter.setStateAsync('info.haBrokerStatus', { val: 'unknown', ack: true });
+		await adapter.subscribeStatesAsync('info.haBrokerStatus');
 	}
 }
 


### PR DESCRIPTION
Handle HomeAssistant restart by responding to homeassistant/status messages, and perform full update of all devices when HA becomes online.

When using MQTT broker as an addon of HA, after restart all discovered devices and entities still exist, but their values are missing (unknown). This change attempts to backfill the values by:
* Fixed a typo in the subscribed topic `homeassistant/status`
* Performed a 'full update' for each device in the dict as if they just became online
* Sent `online` to `/iob/info/status` so that the top level device can be updated (`binary_sensor.*_device_connection_to_cloud`) 
