### PR TITLE
River 3 Plus: fix scaling factor of bmsBattAmp

### DIFF
--- a/lib/dict_data/ef_river3plus_data.js
+++ b/lib/dict_data/ef_river3plus_data.js
@@ -176,7 +176,7 @@ const deviceStates = {
                 min: -80,
                 max: 80,
                 unit_of_measurement: 'A',
-                mult: 1,
+                mult: 0.001,
                 entity_type: 'sensor',
                 device_class: 'current',
                 role: 'value',


### PR DESCRIPTION
bmsBattAmp needs to be scaled by 0.001 like cmsBattAmp. Without this change I see -82A on an idle power station.